### PR TITLE
Fix skip button functionality for answers

### DIFF
--- a/src/app/shared/components/sidebar/sidebar.ts
+++ b/src/app/shared/components/sidebar/sidebar.ts
@@ -92,9 +92,11 @@ export class Sidebar {
   skipRest() {
     // Skip the rest of the flow - collect answers and navigate to loading
     console.log('⏭️  User chose to skip the rest of the flow');
-    this.collectAndLogAnswers();
+    const answersData = this.collectAndLogAnswers();
     this.closeSidebar.emit();
-    this.router.navigate(['/loading']);
+    this.router.navigate(['/loading'], {
+      state: { answers: answersData },
+    });
   }
 
   // Collect all answers and log them to console (same as flow component)


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Pass collected answers to the loading page when 'Skip the rest' is clicked to correctly end the flow.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, clicking 'Skip the rest' caused a page refresh because the `LoadingComponent` did not receive the expected answer data in the router state, leading it to redirect back to the flow page. This change ensures the answers are passed, allowing the flow to terminate correctly.